### PR TITLE
Use rimraf for cross-platform support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build-ts && npm run tslint",
     "build-react": "./node_modules/.bin/webpack-dev-server --config webpack.config.dev.js",
     "build-ts": "tsc",
-    "clean": "rm -rf public && mkdir -p public",
+    "clean": "rimraf public && mkdir public",
     "serve": "./node_modules/.bin/nodemon public/lib/server.js",
     "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run serve\" \"npm run build-react\"",
     "tslint": "tslint -c tslint.json -p tsconfig.json",
@@ -34,7 +34,8 @@
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "@types/body-parser": "^1.16.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5886,6 +5886,13 @@ rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
Two small changes to support running this on Windows:

* Using `rimraf` instead of `rm-rf` 
* Removing `-p` from `mkdir`. (I don't think it's needed, because `public` will always be removed and doesn't need any parents created)